### PR TITLE
Fixed regular expression.

### DIFF
--- a/src/nip.py
+++ b/src/nip.py
@@ -131,7 +131,7 @@ class DynamicBackend:
 
     def handle_subdomains(self, qname):
         subdomain = qname[0:qname.find(self.domain) - 1]
-        match = re.findall('^(?:.+\.)?(\d{1,3}([-.])\d{1,3}\2\d{1,3}\2\d{1,3})$', subdomain)
+        match = re.findall('^(?:.+\.)?(\d{1,3}[-.]\d{1,3}[-.]\d{1,3}[-.]\d{1,3})$', subdomain)
 
         if not match:
             if DEBUG:


### PR DESCRIPTION
In python 2.7.13-2, if the 134th line of nip.py is as follows
     match = re.findall('^(?:.+\.)?(\d{1,3}([-.])\d{1,3}\2\d{1,3}\2\d{1,3})$', subdomain)
The execution result of dig will be as follows.
$ dig 1.2.3.4.example.com +short @localhost
127.0.0.1
$

As a result of correcting the 134th line as follows,
     match = re.findall('^(?:.+\.)?(\d{1,3}[-.]\d{1,3}[-.]\d{1,3}[-.]\d{1,3})$', subdomain)
The execution result of dig is corrected as follows.
$ dig 1-2-3-4.example.com +short @localhost
1.2.3.4
$