### PR TITLE
Allow ip subdomain part to be prefixed with dash

### DIFF
--- a/src/nip.py
+++ b/src/nip.py
@@ -146,7 +146,7 @@ class DynamicBackend:
 
     def handle_subdomains(self, qname):
         subdomain = qname[0:qname.find(self.domain) - 1]
-        match = re.findall('^(?:.+\.)?(\d{1,3}[-.]\d{1,3}[-.]\d{1,3}[-.]\d{1,3})$', subdomain)
+        match = re.findall('^(?:.+[-.])?(\d{1,3}[-.]\d{1,3}[-.]\d{1,3}[-.]\d{1,3})$', subdomain)
 
         if not match:
             if DEBUG:


### PR DESCRIPTION
This is useful so sub-sub-domains can make use of wildcard certificate
e.g. myapp-myenvironment-10-9-8-7.mydomain.com